### PR TITLE
Align scrollbar styling with site theme

### DIFF
--- a/style.css
+++ b/style.css
@@ -28,30 +28,37 @@ body {
     min-height: 100vh;
 }
 
-/* Theme-aligned scrollbar for consistent polished visuals */
-body {
+/* Theme-aligned scrollbar to avoid stark white chrome and match the deep blue palette */
+html {
     scrollbar-width: thin;
-    scrollbar-color: var(--accent) rgba(15, 23, 42, 0.6);
+    scrollbar-color: var(--accent-strong) rgba(15, 23, 42, 0.78);
 }
 
 body::-webkit-scrollbar {
     width: 12px;
+    background-color: rgba(15, 23, 42, 0.78);
 }
 
 body::-webkit-scrollbar-track {
-    background: rgba(15, 23, 42, 0.6);
+    background: linear-gradient(180deg, rgba(15, 23, 42, 0.9), rgba(15, 23, 42, 0.7));
     border-radius: 999px;
+    border: 2px solid rgba(2, 6, 23, 0.6);
+    box-shadow: inset 0 2px 6px rgba(2, 6, 23, 0.55);
 }
 
 body::-webkit-scrollbar-thumb {
     background: linear-gradient(180deg, var(--accent), var(--accent-strong));
     border-radius: 999px;
-    border: 3px solid rgba(30, 41, 59, 0.8);
-    box-shadow: inset 0 0 6px rgba(15, 23, 42, 0.35);
+    border: 3px solid rgba(15, 23, 42, 0.85);
+    box-shadow: inset 0 0 6px rgba(8, 47, 73, 0.45);
 }
 
 body::-webkit-scrollbar-thumb:hover {
-    background: var(--accent-strong);
+    background: linear-gradient(180deg, var(--accent-strong), #0284c7);
+}
+
+body::-webkit-scrollbar-corner {
+    background: rgba(15, 23, 42, 0.9);
 }
 
 .page-wrapper {


### PR DESCRIPTION
## Summary
- restyle the custom scrollbar to use the site's blue palette instead of the default white chrome
- adjust the scrollbar track, thumb, and corner to include depth and gradients for a cohesive appearance
- ensure Firefox receives matching colors via scrollbar-color on the root element

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f3b28b99ec832bb74c61326f4ccca8