### PR TITLE
Fine tune academic timeline guideline alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -183,28 +183,47 @@ main {
 }
 
 .timeline {
+    /* Shared marker measurements keep the guideline anchored to the bullets. */
+    --timeline-marker-offset: -0.65rem;
+    --timeline-marker-size: 0.75rem;
+    --timeline-marker-top-gap: 0.35rem;
+    --timeline-line: rgba(148, 163, 184, 0.2);
     list-style: none;
     margin: 1.5rem 0 0;
     padding: 0;
-    border-left: 2px solid rgba(148, 163, 184, 0.2);
+    position: relative;
+}
+
+.timeline::before {
+    content: "";
+    position: absolute;
+    /* Slight nudge keeps the guideline perfectly centered with the first bullet. */
+    left: calc(var(--timeline-marker-offset) + (var(--timeline-marker-size) / 2) - 1px);
+    top: calc(var(--timeline-marker-top-gap) + (var(--timeline-marker-size) / 2));
+    bottom: 0;
+    width: 2px;
+    background: var(--timeline-line);
+    z-index: 0;
 }
 
 .timeline li {
     position: relative;
     padding-left: 1.5rem;
     margin-bottom: 1.75rem;
+    z-index: 1;
 }
 
 .timeline li::before {
     content: "";
     position: absolute;
-    left: -0.65rem;
-    top: 0.35rem;
-    width: 0.75rem;
-    height: 0.75rem;
+    left: var(--timeline-marker-offset);
+    top: var(--timeline-marker-top-gap);
+    width: var(--timeline-marker-size);
+    height: var(--timeline-marker-size);
     background: var(--accent);
     border-radius: 50%;
     box-shadow: 0 0 0 4px rgba(56, 189, 248, 0.15);
+    z-index: 1;
 }
 
 .timeline__meta {


### PR DESCRIPTION
## Summary
- shift the academic background guideline 1px left so it stems from the bullet center
- document the position tweak with an inline comment for future adjustments

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68f3b301f3ac832b9a1d744419765d87