### PR TITLE
Align academic timeline guideline with bullet markers

### DIFF
--- a/style.css
+++ b/style.css
@@ -211,13 +211,15 @@ main {
 .timeline::before {
     content: "";
     position: absolute;
-    /* Slight nudge keeps the guideline perfectly centered with the first bullet. */
-    left: calc(var(--timeline-marker-offset) + (var(--timeline-marker-size) / 2) - 1px);
+    /* Keep the spine perfectly centered with each marker for a clean vertical read. */
+    left: calc(var(--timeline-marker-offset) + (var(--timeline-marker-size) / 2));
+    /* Start the spine halfway through the first marker so it visually stems from it. */
     top: calc(var(--timeline-marker-top-gap) + (var(--timeline-marker-size) / 2));
-    bottom: 0;
+    bottom: calc(var(--timeline-marker-top-gap) - (var(--timeline-marker-size) / 2));
     width: 2px;
     background: var(--timeline-line);
     z-index: 0;
+    transform: translateX(-50%);
 }
 
 .timeline li {


### PR DESCRIPTION
## Summary
- realign the academic background timeline spine so it originates from the center of the bullet markers for improved visual consistency

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f3b6e5126c832b982c7ce5fda40b41