### PR TITLE
Redesign portfolio with industrial field journal theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,10 +20,27 @@
                     <li><a href="#projects">Projects</a></li>
                 </ul>
             </nav>
-            <div class="hero-content" id="top">
-                <h1>Elwood Hogan</h1>
-                <p>Software engineer crafting intuitive digital experiences.</p>
-                <a class="primary-btn" href="#projects">View Projects</a>
+            <div class="hero-grid" id="top">
+                <div class="hero-content">
+                    <h1>Elwood Hogan</h1>
+                    <p>
+                        Software engineer shaping tactile, story-driven interfaces that feel more
+                        analog than algorithmic.
+                    </p>
+                    <div class="hero-cta">
+                        <a class="primary-btn" href="#projects">View Projects</a>
+                        <a class="secondary-btn" href="#resume">See Resume</a>
+                    </div>
+                </div>
+                <aside class="hero-note">
+                    <!-- Quick hits reinforce the industrial field-journal aesthetic. -->
+                    <h2>Field Notes</h2>
+                    <ul>
+                        <li>Hand-built tools for educators and storytellers.</li>
+                        <li>Rapid prototyping without glossy finishes.</li>
+                        <li>Systems thinking grounded in human rituals.</li>
+                    </ul>
+                </aside>
             </div>
         </header>
 

--- a/style.css
+++ b/style.css
@@ -1,86 +1,80 @@
 :root {
-    --bg: #0f172a;
-    --surface: #1e293b;
-    --accent: #38bdf8;
-    --accent-strong: #0ea5e9;
-    --text: #e2e8f0;
-    --muted: #94a3b8;
-    --card-radius: 18px;
-    --max-width: 960px;
-    --transition: 0.25s ease;
+    /* Palette tuned for a print-inspired, industrial theme. */
+    --bg: #1b1611;
+    --surface: #241d16;
+    --paper: #30261c;
+    --line: #4b4234;
+    --accent: #d96c06;
+    --accent-strong: #f2d16b;
+    --text: #f3f1e3;
+    --muted: #b0a79a;
+    --max-width: 1040px;
+    --transition: 0.2s ease;
 }
 
-/* Base document styling for consistent typography */
+/* Foundation ------------------------------------------------------------- */
 * {
     box-sizing: border-box;
 }
 
-/* Enable smooth scrolling for in-page navigation links */
 html {
     scroll-behavior: smooth;
 }
 
 body {
     margin: 0;
-    font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+    font-family: "IBM Plex Sans", "Helvetica Neue", Arial, sans-serif;
     color: var(--text);
-    background: radial-gradient(circle at top, #1e3a8a, var(--bg));
+    background-color: var(--bg);
+    /* SVG grid keeps the background tactile without relying on gradients. */
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160' viewBox='0 0 160 160'%3E%3Crect width='160' height='160' fill='none' stroke='%234b4234' stroke-width='3'/%3E%3Cpath d='M0 40h160M0 80h160M0 120h160M40 0v160M80 0v160M120 0v160' stroke='%23352c21' stroke-width='1'/%3E%3C/svg%3E");
+    background-size: 160px 160px;
+    background-attachment: fixed;
     min-height: 100vh;
 }
 
-/* Align the scrollbar with the twilight blue theme */
 html {
     scrollbar-width: thin;
-    scrollbar-color: var(--accent) rgba(2, 6, 23, 0.82);
+    scrollbar-color: var(--accent) var(--surface);
 }
 
-/* Dedicated scrollbar styling for Chromium/WebKit browsers */
 html::-webkit-scrollbar,
 body::-webkit-scrollbar {
-    width: 8px;
-    height: 8px;
-    background-color: transparent;
+    width: 10px;
+    height: 10px;
 }
 
-/* Rounded gradient track keeps the scrollbar visually soft against the page. */
 html::-webkit-scrollbar-track,
 body::-webkit-scrollbar-track {
-    background: linear-gradient(180deg, rgba(15, 23, 42, 0.55), rgba(30, 41, 59, 0.35));
-    border-radius: 999px;
-    margin: 2px;
-    border: 1px solid rgba(30, 64, 175, 0.2);
-    box-shadow: inset 0 1px 3px rgba(8, 47, 73, 0.35);
+    background: var(--surface);
+    border: 2px solid var(--line);
 }
 
-/* A pill-shaped thumb echoes the rounded card corners for cohesion. */
 html::-webkit-scrollbar-thumb,
 body::-webkit-scrollbar-thumb {
-    background: linear-gradient(180deg, rgba(56, 189, 248, 0.9), rgba(14, 165, 233, 0.8));
-    border-radius: 999px;
-    border: 2px solid rgba(15, 23, 42, 0.8);
-    box-shadow: 0 0 6px rgba(14, 165, 233, 0.4);
+    background: var(--accent);
+    border: 2px solid var(--surface);
 }
 
 html::-webkit-scrollbar-thumb:hover,
 body::-webkit-scrollbar-thumb:hover {
-    background: linear-gradient(180deg, rgba(14, 165, 233, 0.95), rgba(2, 132, 199, 0.9));
+    background: var(--accent-strong);
 }
-
-html::-webkit-scrollbar-corner,
-body::-webkit-scrollbar-corner {
-    background-color: rgba(2, 6, 23, 0.65);
-}
-  
 
 .page-wrapper {
     display: flex;
     flex-direction: column;
     min-height: 100vh;
+    background-color: rgba(27, 22, 17, 0.94);
+    border-left: 6px solid var(--accent);
+    border-right: 6px solid var(--accent);
 }
 
+/* Navigation ------------------------------------------------------------- */
 .hero {
-    background: linear-gradient(135deg, rgba(56, 189, 248, 0.1), rgba(14, 165, 233, 0.05));
-    padding: 2.5rem 1.5rem 5rem;
+    background: var(--surface);
+    padding: 2.5rem 1.5rem 4rem;
+    border-bottom: 4px solid var(--accent);
 }
 
 .top-nav {
@@ -90,20 +84,23 @@ body::-webkit-scrollbar-corner {
     gap: 1rem;
     max-width: var(--max-width);
     margin: 0 auto 3rem;
+    border-bottom: 2px solid var(--line);
+    padding-bottom: 1rem;
 }
 
 .brand {
-    font-size: 1.25rem;
+    font-size: 1.35rem;
     font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
     color: var(--text);
     text-decoration: none;
-    letter-spacing: 0.04em;
 }
 
 .nav-links {
     display: flex;
     list-style: none;
-    gap: 1.25rem;
+    gap: 1.5rem;
     margin: 0;
     padding: 0;
 }
@@ -111,30 +108,47 @@ body::-webkit-scrollbar-corner {
 .nav-links a {
     color: var(--muted);
     text-decoration: none;
-    font-weight: 500;
-    transition: color var(--transition);
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    border-bottom: 2px solid transparent;
+    transition: color var(--transition), border-color var(--transition);
 }
 
 .nav-links a:hover,
 .nav-links a:focus {
-    color: var(--accent);
+    color: var(--accent-strong);
+    border-color: var(--accent-strong);
 }
 
-.hero-content {
+/* Hero ------------------------------------------------------------------ */
+.hero-grid {
     max-width: var(--max-width);
     margin: 0 auto;
-    text-align: left;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 2rem;
+    align-items: start;
 }
 
 .hero-content h1 {
-    font-size: clamp(2.5rem, 4vw + 1rem, 4.25rem);
-    margin-bottom: 0.75rem;
+    font-size: clamp(2.75rem, 5vw + 1rem, 4.5rem);
+    margin: 0 0 1rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
 }
 
 .hero-content p {
-    font-size: 1.15rem;
+    font-size: 1.2rem;
     color: var(--muted);
-    margin-bottom: 2rem;
+    margin: 0 0 2rem;
+    line-height: 1.5;
+}
+
+.hero-cta {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
 }
 
 .primary-btn,
@@ -142,173 +156,195 @@ body::-webkit-scrollbar-corner {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    gap: 0.5rem;
-    padding: 0.85rem 1.75rem;
-    border-radius: 999px;
-    font-weight: 600;
+    padding: 0.95rem 1.85rem;
+    border: 2px solid var(--line);
+    background: transparent;
+    color: var(--text);
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
     text-decoration: none;
-    transition: transform var(--transition), background var(--transition);
+    transition: background var(--transition), color var(--transition), border-color var(--transition);
 }
 
 .primary-btn {
+    border-color: var(--accent);
     background: var(--accent);
-    color: var(--bg);
+    color: #1a130c;
 }
 
 .primary-btn:hover,
 .primary-btn:focus {
     background: var(--accent-strong);
-    transform: translateY(-2px);
+    border-color: var(--accent-strong);
+    color: #21180f;
 }
 
 .secondary-btn {
-    border: 1px solid rgba(148, 163, 184, 0.4);
-    color: var(--text);
-    background: rgba(30, 41, 59, 0.6);
+    border-color: var(--line);
 }
 
 .secondary-btn:hover,
 .secondary-btn:focus {
     border-color: var(--accent);
-    color: var(--accent);
-    transform: translateY(-2px);
+    color: var(--accent-strong);
 }
 
+.hero-note {
+    background: var(--paper);
+    border: 2px solid var(--line);
+    padding: 1.5rem;
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.hero-note h2 {
+    margin: 0 0 1rem;
+    font-size: 1.1rem;
+    color: var(--accent-strong);
+}
+
+.hero-note ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.hero-note li {
+    position: relative;
+    padding-left: 1.5rem;
+    line-height: 1.4;
+}
+
+.hero-note li::before {
+    content: "\25A0";
+    position: absolute;
+    left: 0;
+    top: 0;
+    color: var(--accent);
+}
+
+/* Main content ---------------------------------------------------------- */
 main {
     flex: 1;
     padding: 0 1.5rem 4rem;
 }
 
 .card {
-    background: rgba(15, 23, 42, 0.75);
-    border: 1px solid rgba(148, 163, 184, 0.18);
-    border-radius: var(--card-radius);
-    padding: 2rem;
-    margin: -3rem auto 2rem;
+    background: var(--paper);
+    border: 2px solid var(--line);
+    padding: 2.5rem;
+    margin: 3rem auto 2.5rem;
     max-width: var(--max-width);
-    backdrop-filter: blur(10px);
-    box-shadow: 0 20px 45px rgba(15, 23, 42, 0.4);
+    box-shadow: 12px 12px 0 #120d08;
 }
 
 .card h2 {
-    margin-top: 0;
-    font-size: 1.75rem;
+    margin: 0 0 1.25rem;
+    font-size: 1.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
 }
 
 .card p {
     color: var(--muted);
-    line-height: 1.6;
+    line-height: 1.7;
+    max-width: 60ch;
 }
 
 .timeline {
-    /* Shared marker measurements keep the guideline anchored to the bullets. */
-    --timeline-marker-offset: -0.65rem;
-    --timeline-marker-size: 0.75rem;
-    --timeline-marker-top-gap: 0.35rem;
-    --timeline-line: rgba(148, 163, 184, 0.2);
     list-style: none;
-    margin: 1.5rem 0 0;
+    margin: 2rem 0 0;
     padding: 0;
-    position: relative;
-}
-
-.timeline::before {
-    content: "";
-    position: absolute;
-    /* Keep the spine perfectly centered with each marker for a clean vertical read. */
-    left: calc(var(--timeline-marker-offset) + (var(--timeline-marker-size) / 2));
-    /* Start the spine halfway through the first marker so it visually stems from it. */
-    top: calc(var(--timeline-marker-top-gap) + (var(--timeline-marker-size) / 2));
-    bottom: calc(var(--timeline-marker-top-gap) - (var(--timeline-marker-size) / 2));
-    width: 2px;
-    background: var(--timeline-line);
-    z-index: 0;
-    transform: translateX(-50%);
+    border-left: 3px solid var(--accent);
 }
 
 .timeline li {
-    position: relative;
     padding-left: 1.5rem;
-    margin-bottom: 1.75rem;
-    z-index: 1;
+    margin-bottom: 2rem;
+    position: relative;
 }
 
 .timeline li::before {
     content: "";
     position: absolute;
-    left: var(--timeline-marker-offset);
-    top: var(--timeline-marker-top-gap);
-    width: var(--timeline-marker-size);
-    height: var(--timeline-marker-size);
-    background: var(--accent);
-    border-radius: 50%;
-    box-shadow: 0 0 0 4px rgba(56, 189, 248, 0.15);
-    z-index: 1;
+    left: -11px;
+    top: 0.4rem;
+    width: 14px;
+    height: 14px;
+    border: 2px solid var(--accent);
+    background: var(--surface);
 }
 
 .timeline__meta {
     display: block;
-    color: var(--accent);
-    font-weight: 600;
+    color: var(--accent-strong);
+    font-weight: 700;
     margin-bottom: 0.35rem;
+    letter-spacing: 0.05em;
 }
 
 .language-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 1.5rem;
-    margin-top: 1.5rem;
+    gap: 1.75rem;
+    margin-top: 2rem;
 }
 
 .language {
-    padding: 1.25rem;
-    border-radius: 1rem;
-    background: rgba(30, 41, 59, 0.6);
-    border: 1px solid rgba(148, 163, 184, 0.12);
-    transition: transform var(--transition), border var(--transition);
+    border: 2px solid var(--line);
+    padding: 1.5rem;
+    background: var(--surface);
+    color: var(--muted);
+    transition: transform var(--transition), border-color var(--transition);
 }
 
 .language:hover {
-    transform: translateY(-4px);
-    border-color: rgba(56, 189, 248, 0.35);
+    transform: translateY(-6px);
+    border-color: var(--accent);
 }
 
 .project-showcase {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 1.5rem;
-    margin-top: 1.75rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.75rem;
+    margin-top: 2rem;
 }
 
 .project {
-    padding: 1.5rem;
-    border-radius: 1rem;
-    background: rgba(30, 41, 59, 0.6);
-    border: 1px solid rgba(148, 163, 184, 0.12);
+    border: 2px solid var(--line);
+    padding: 1.75rem;
+    background: var(--surface);
     color: var(--muted);
-    line-height: 1.6;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
 }
 
+/* Footer --------------------------------------------------------------- */
 .footer {
     text-align: center;
-    padding: 2rem 1.5rem 3rem;
+    padding: 2.5rem 1.5rem 3rem;
     color: var(--muted);
     font-size: 0.95rem;
-    border-top: 1px solid rgba(148, 163, 184, 0.12);
-    background: rgba(15, 23, 42, 0.85);
+    border-top: 4px solid var(--accent);
+    background: var(--surface);
 }
 
 .footer-links {
     display: flex;
     justify-content: center;
-    gap: 1.75rem;
-    margin-top: 1rem;
+    gap: 2rem;
+    margin-top: 1.25rem;
 }
 
 .footer a {
     color: var(--accent);
     text-decoration: none;
-    transition: color var(--transition);
+    font-weight: 600;
+    letter-spacing: 0.05em;
 }
 
 .footer a:hover,
@@ -316,6 +352,7 @@ main {
     color: var(--accent-strong);
 }
 
+/* Responsive adjustments ------------------------------------------------ */
 @media (max-width: 720px) {
     .top-nav {
         flex-direction: column;
@@ -328,7 +365,8 @@ main {
     }
 
     .card {
-        margin: -2.5rem auto 2rem;
-        padding: 1.75rem;
+        margin: 2rem auto;
+        padding: 2rem;
+        box-shadow: 8px 8px 0 #120d08;
     }
 }


### PR DESCRIPTION
## Summary
- replace the hero section with a grid layout and field notes callout to emphasize the analog-inspired portfolio story
- restyle the site with a print-inspired industrial palette, rigid edges, and grid background to remove blue, gradient, and rounded motifs

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68f3c307f8a0832bbc300007c562b79d